### PR TITLE
rfb-proto: Move defmt behind feature flag

### DIFF
--- a/RTIC-atomic/Cargo.toml
+++ b/RTIC-atomic/Cargo.toml
@@ -11,7 +11,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 
 [dependencies.stm32f4xx-hal]
 version = "0.13.2"

--- a/RTIC-counter-peripheral/Cargo.toml
+++ b/RTIC-counter-peripheral/Cargo.toml
@@ -11,7 +11,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 systick-monotonic = "1.0.0"
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 
 stm32f4xx-hal = { version = "0.14.0", features = [
     "stm32f411",

--- a/RTIC-queues/Cargo.toml
+++ b/RTIC-queues/Cargo.toml
@@ -11,7 +11,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 
 [dependencies.stm32f4xx-hal]
 version = "0.14.0"

--- a/RTIC-shared/Cargo.toml
+++ b/RTIC-shared/Cargo.toml
@@ -11,7 +11,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 
 [dependencies.stm32f4xx-hal]
 version = "0.13.2"

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -460,35 +460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
-dependencies = [
- "bitflags",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
-dependencies = [
- "defmt-parser",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,7 +1430,6 @@ version = "1.0.2"
 source = "git+https://github.com/jamesmunns/postcard#56d0a58bcfebe8e80db9920410ea6036c3cab32f"
 dependencies = [
  "cobs",
- "defmt",
  "heapless",
  "serde",
 ]
@@ -1560,7 +1530,6 @@ dependencies = [
 name = "rfb-proto"
 version = "0.1.0"
 dependencies = [
- "defmt",
  "heapless",
  "postcard",
  "serde",

--- a/embassy-select-pathological/Cargo.toml
+++ b/embassy-select-pathological/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 panic-probe = { version = "0.3.0" }
 embassy-executor = { version = "0.1.0", features = [
     "defmt",

--- a/embassy-tasks-channels/Cargo.toml
+++ b/embassy-tasks-channels/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 panic-probe = { version = "0.3.0" }
 embassy-executor = { version = "0.1.0", features = [
     "defmt",

--- a/embassy-tasks/Cargo.toml
+++ b/embassy-tasks/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 panic-probe = { version = "0.3.0" }
 embassy-executor = { version = "0.1.0", features = [
     "defmt",

--- a/freertos-tasks/Cargo.toml
+++ b/freertos-tasks/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 panic-probe = { version = "0.3.0" }
 defmt = "0.3.0"
 defmt-rtt = "0.3.2"

--- a/hal-blocking/Cargo.toml
+++ b/hal-blocking/Cargo.toml
@@ -14,7 +14,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 postcard = "1.0.2"
 
 [dependencies.stm32f4xx-hal]

--- a/mutex-cell/Cargo.toml
+++ b/mutex-cell/Cargo.toml
@@ -14,7 +14,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 postcard = "1.0.2"
 
 [dependencies.stm32f4xx-hal]

--- a/pac-blocking/Cargo.toml
+++ b/pac-blocking/Cargo.toml
@@ -14,7 +14,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 
 [dependencies.stm32f4xx-hal]
 version = "0.13.2"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2021"
 [features]
 actuator = []
 sensor = []
+use-defmt = ["dep:defmt", "postcard/use-defmt"]
 
 [dependencies]
 heapless = "0.7.16"
-postcard = { git = "https://github.com/jamesmunns/postcard", features = [
-    "use-defmt",
-] }
+postcard = { git = "https://github.com/jamesmunns/postcard" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 snafu = { version = "0.7.2", features = [
     "rust_1_46",
 ], default-features = false }
-defmt = "0.3.2"
+defmt = { version = "0.3.2", optional = true }

--- a/proto/src/actuator.rs
+++ b/proto/src/actuator.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "actuator")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, defmt::Format)]
+#[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[repr(C)]
 pub enum Request {
     Generate {
@@ -12,7 +13,8 @@ pub enum Request {
 }
 
 #[cfg(feature = "actuator")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, defmt::Format)]
+#[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[repr(C)]
 pub enum Response {
     StartedGenerating,

--- a/proto/src/sensor.rs
+++ b/proto/src/sensor.rs
@@ -1,14 +1,16 @@
 use postcard::fixint;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, defmt::Format)]
+#[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[repr(C)]
 pub enum Request {
     GetCount,
     WhoAreYou,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, defmt::Format)]
+#[cfg_attr(feature = "use-defmt", derive(defmt::Format))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[repr(C)]
 pub enum Response<'a> {
     #[serde(with = "fixint::le")]

--- a/raw-interrupts-pathological/Cargo.toml
+++ b/raw-interrupts-pathological/Cargo.toml
@@ -14,7 +14,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 postcard = "1.0.2"
 
 [dependencies.stm32f4xx-hal]

--- a/raw-interrupts/Cargo.toml
+++ b/raw-interrupts/Cargo.toml
@@ -14,7 +14,7 @@ defmt = "0.3.2"
 defmt-rtt = "0.3.2"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
-rfb-proto = { path = "../proto", features = ["sensor"] }
+rfb-proto = { path = "../proto", features = ["sensor", "use-defmt"] }
 postcard = "1.0.2"
 
 [dependencies.stm32f4xx-hal]


### PR DESCRIPTION
Requiring `defmt` does prevent use of protocol crate in Windows tools (linker errors), as the crate seems not to be intended to be built on host OSes.

This moves uses of the crate behind a feature flag that is only enabled in the embedded crates.